### PR TITLE
Update fly token

### DIFF
--- a/.github/workflows/merge-to-main.yml
+++ b/.github/workflows/merge-to-main.yml
@@ -7,14 +7,16 @@ on:
 env:
   APOLLO_KEY: ${{ secrets.APOLLO_KEY }}
   APOLLO_VCS_COMMIT: ${{ github.event.pull_request.head.sha }}
-  FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
+  FLY_API_TOKEN: ${{ secrets.SHANES_FLY_API_TOKEN }}
 
 jobs:
   subgraph-users:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
+
       - uses: superfly/flyctl-actions/setup-flyctl@master
+
       - name: Install Rover
         run: |
           curl -sSL https://rover.apollo.dev/nix/latest | sh

--- a/.github/workflows/pr-check-code.yml
+++ b/.github/workflows/pr-check-code.yml
@@ -35,6 +35,10 @@ jobs:
           curl -sSL https://rover.apollo.dev/nix/latest | sh
           echo "$HOME/.rover/bin" >> $GITHUB_PATH
 
+      - name: Rover whoami
+        run: |
+          rover config whoami
+
       - name: Check users subgraph
         run: |
           rover subgraph check apollo-financial-supergraph@prod \


### PR DESCRIPTION
Fly tokens can not be created for orgs, only personal tokens today. For now I have saved one of my personal tokens to the GitHub org for all repos to use. I will update this once the feature becomes available

https://community.fly.io/t/feature-request-limit-access-tokens-to-certain-organizations/1507