### PR TITLE
Make BankAccount an entity

### DIFF
--- a/subgraphs/accounts/data.js
+++ b/subgraphs/accounts/data.js
@@ -2,11 +2,13 @@ export const ACCOUNTS = [
   {
     id: "account:1",
     name: "Account One",
-    type: "CHECKING"
+    type: "CHECKING",
+    tier: "BASIC"
   },
   {
     id: "account:2",
     name: "Account Two",
-    type: "SAVINGS"
+    type: "SAVINGS",
+    tier: "PREMIUM"
   },
 ];

--- a/subgraphs/accounts/data.js
+++ b/subgraphs/accounts/data.js
@@ -1,10 +1,12 @@
 export const ACCOUNTS = [
   {
     id: "account:1",
-    name: "Account One"
+    name: "Account One",
+    type: "CHECKING"
   },
   {
     id: "account:2",
-    name: "Account Two"
+    name: "Account Two",
+    type: "SAVINGS"
   },
 ];

--- a/subgraphs/accounts/resolvers.js
+++ b/subgraphs/accounts/resolvers.js
@@ -4,9 +4,14 @@ export const getAccountById = (id) => ACCOUNTS.find((it) => it.id === id);
 
 export const resolvers = {
   Query: {
-    accounts: () => ACCOUNTS
+    bankAccounts: () => ({})
   },
-  Account: {
+  BankAccountsResponse: {
+    all: () => ACCOUNTS,
+    checking: () => ACCOUNTS.filter(it => it.type === "CHECKING"),
+    savings: () => ACCOUNTS.filter(it => it.type === "SAVINGS")
+  },
+  BankAccount: {
     __resolveReference(ref) {
       return getAccountById(ref.id);
     }

--- a/subgraphs/accounts/schema.graphql
+++ b/subgraphs/accounts/schema.graphql
@@ -1,5 +1,14 @@
 # noinspection GraphQLTypeRedefinition
 
+type Query {
+  bankAccounts: BankAccountsResponse
+}
+
+type Mutation {
+  openCheckingAccount(tier: BankAccountTier): BankAccountsResponse
+  openSavingsAccount(tier: BankAccountTier): BankAccountsResponse
+}
+
 enum BankAccountType {
   CHECKING
   SAVINGS
@@ -11,17 +20,7 @@ enum BankAccountTier {
   VIP
 }
 
-interface BankAccount {
-  id: ID!
-}
-
-type CheckingAccount implements BankAccount @key(fields: "id") {
-  id: ID!
-  type: BankAccountType
-  tier: BankAccountTier
-}
-
-type SavingsAccount implements BankAccount @key(fields: "id") {
+type BankAccount @key(fields: "id") {
   id: ID!
   type: BankAccountType
   tier: BankAccountTier
@@ -29,15 +28,6 @@ type SavingsAccount implements BankAccount @key(fields: "id") {
 
 type BankAccountsResponse {
   all: [BankAccount]
-  checking: [CheckingAccount]
-  savings: [SavingsAccount]
-}
-
-type Query {
-  bankAccounts: BankAccountsResponse
-}
-
-type Mutation {
-  openCheckingAccount(tier: BankAccountTier): BankAccountsResponse
-  openSavingsAccount(tier: BankAccountTier): BankAccountsResponse
+  checking: [BankAccount]
+  savings: [BankAccount]
 }

--- a/subgraphs/accounts/schema.graphql
+++ b/subgraphs/accounts/schema.graphql
@@ -22,6 +22,7 @@ enum BankAccountTier {
 
 type BankAccount @key(fields: "id") {
   id: ID!
+  name: String
   type: BankAccountType
   tier: BankAccountTier
 }

--- a/subgraphs/credit/schema.graphql
+++ b/subgraphs/credit/schema.graphql
@@ -29,11 +29,7 @@ type CreditCardApplication @key(fields: "id"){
   status: CreditApplicationStatus
 }
 
-interface BankAccount {
-  id: ID!
-}
-
-type CreditCardAccount implements BankAccount @key(fields: "id") {
+type BankAccount @key(fields: "id") {
   id: ID!
   type: BankAccountType
   tier: BankAccountTier

--- a/subgraphs/transactions/data.js
+++ b/subgraphs/transactions/data.js
@@ -1,10 +1,12 @@
 export const TRANSACTIONS = [
   {
     id: "transaction:1",
+    accountId: "account:1",
     name: "Transaction One"
   },
   {
     id: "transaction:2",
+    accountId: "account:2",
     name: "Transaction Two"
   },
 ];

--- a/subgraphs/transactions/resolvers.js
+++ b/subgraphs/transactions/resolvers.js
@@ -1,10 +1,14 @@
 import { TRANSACTIONS } from "./data.js";
 
 export const getTransactionById = (id) => TRANSACTIONS.find((it) => it.id === id);
+export const getTransactionsByAccountId = (accountId) => TRANSACTIONS.filter((it) => it.accountId === accountId);
 
 export const resolvers = {
   Query: {
     transactions: () => TRANSACTIONS
+  },
+  BankAccount: {
+    transactions: (parent) => getTransactionsByAccountId(parent.id)
   },
   Transaction: {
     __resolveReference(ref) {

--- a/subgraphs/transactions/schema.graphql
+++ b/subgraphs/transactions/schema.graphql
@@ -7,28 +7,12 @@ enum TransactionType {
 
 type Transaction @key(fields: "id") {
   id: ID!
-  ammount: Int
+  amount: Int
   description: String
   account: BankAccount
 }
 
-interface BankAccount {
-  id: ID!
-}
-
-type CheckingAccount implements BankAccount @key(fields: "id") {
-  id: ID!
-  transactions: [Transaction]
-  balance: Int
-}
-
-type SavingsAccount implements BankAccount @key(fields: "id") {
-  id: ID!
-  transactions: [Transaction]
-  balance: Int
-}
-
-type CreditCardAccount implements BankAccount @key(fields: "id") {
+type BankAccount @key(fields: "id") {
   id: ID!
   transactions: [Transaction]
   balance: Int
@@ -49,8 +33,8 @@ type InsufficientFundsError {
 union TransactionResult = InsufficientFundsError | TransactionApproved | TransactionDeclined
 
 type Mutation {
-  debitFromAccount(account: ID!, ammount: Int!): TransactionResult
-  creditToAccount(account: ID!, ammount: Int!): TransactionResult
-  withdrawFromAccount(account: ID!, ammount: Int!): TransactionResult
-  transferFundsBetweenAccounts(fromAccount: ID!, toAccount: ID!, ammount: Int!): TransactionResult
+  debitFromAccount(account: ID!, amount: Int!): TransactionResult
+  creditToAccount(account: ID!, amount: Int!): TransactionResult
+  withdrawFromAccount(account: ID!, amount: Int!): TransactionResult
+  transferFundsBetweenAccounts(fromAccount: ID!, toAccount: ID!, amount: Int!): TransactionResult
 }

--- a/subgraphs/users/data.js
+++ b/subgraphs/users/data.js
@@ -1,10 +1,20 @@
 export const USERS = [
   {
     id: "user:1",
-    name: "User One"
+    name: "User One",
+    accounts: [
+      {
+        id: "accounts:1"
+      }
+    ]
   },
   {
     id: "user:2",
-    name: "User Two"
+    name: "User Two",
+    accounts: [
+      {
+        id: "accounts:2"
+      }
+    ]
   },
 ];

--- a/subgraphs/users/data.js
+++ b/subgraphs/users/data.js
@@ -4,7 +4,7 @@ export const USERS = [
     name: "User One",
     accounts: [
       {
-        id: "accounts:1"
+        id: "account:1"
       }
     ]
   },
@@ -13,7 +13,7 @@ export const USERS = [
     name: "User Two",
     accounts: [
       {
-        id: "accounts:2"
+        id: "account:2"
       }
     ]
   },

--- a/subgraphs/users/resolvers.js
+++ b/subgraphs/users/resolvers.js
@@ -10,5 +10,5 @@ export const resolvers = {
     __resolveReference(ref) {
       return getUserById(ref.id);
     }
-  },
+  }
 };

--- a/subgraphs/users/resolvers.js
+++ b/subgraphs/users/resolvers.js
@@ -9,6 +9,7 @@ export const resolvers = {
   User: {
     __resolveReference(ref) {
       return getUserById(ref.id);
-    }
+    },
+    accounts: (parent) => getUserById(parent.id).accounts
   }
 };

--- a/subgraphs/users/schema.graphql
+++ b/subgraphs/users/schema.graphql
@@ -26,7 +26,12 @@ type Query {
   users: [User]
 }
 
-type User @key(fields: "id") {
+type User @key(fields: "id") @auth(requires: USER) {
   id: ID!
-  name: String @auth(requires: USER)
+  name: String
+  accounts: [BankAccount]
+}
+
+type BankAccount @key(fields: "id", resolvable: false) {
+  id: ID!
 }


### PR DESCRIPTION
Instead of an interface that accounts extend, implement a common account entity that other subgraphs can add fields or types too. This also makes it easier with Federation instead of having to operate on interfaces